### PR TITLE
Added nullcheck on product group and defaultGroupId

### DIFF
--- a/Swift/Files/Templates/Designs/Swift/eCom/ProductCatalog/ProductSlider.cshtml
+++ b/Swift/Files/Templates/Designs/Swift/eCom/ProductCatalog/ProductSlider.cshtml
@@ -183,7 +183,8 @@
 	bool neverShowVat = string.IsNullOrEmpty(showPricesWithVat);
 	
 	var defaultGroupId = product.PrimaryOrDefaultGroup.Id;
-	var selectedDetailPage = Dynamicweb.Ecommerce.Services.ProductGroups.GetGroup(defaultGroupId).Meta.PrimaryPage;
+	var productGroup = Dynamicweb.Ecommerce.Services.ProductGroups.GetGroup(defaultGroupId);
+	var selectedDetailPage = productGroup?.Meta.PrimaryPage ?? "";
 
 	string link = string.IsNullOrEmpty(selectedDetailPage) ? $"/Default.aspx?ID={detailsPageLink}&groupid={defaultGroupId}" : selectedDetailPage;
 	link += "&productid=" + product.Id;

--- a/Swift/Files/Templates/Designs/Swift/eCom/ProductCatalog/ProductSlider.cshtml
+++ b/Swift/Files/Templates/Designs/Swift/eCom/ProductCatalog/ProductSlider.cshtml
@@ -183,7 +183,7 @@
 	bool neverShowVat = string.IsNullOrEmpty(showPricesWithVat);
 	
 	var defaultGroupId = product.PrimaryOrDefaultGroup.Id;
-	var productGroup = Dynamicweb.Ecommerce.Services.ProductGroups.GetGroup(defaultGroupId);
+	var productGroup = !string.IsNullOrEmpty(defaultGroupId) : Dynamicweb.Ecommerce.Services.ProductGroups.GetGroup(defaultGroupId) : null;
 	var selectedDetailPage = productGroup?.Meta.PrimaryPage ?? "";
 
 	string link = string.IsNullOrEmpty(selectedDetailPage) ? $"/Default.aspx?ID={detailsPageLink}&groupid={defaultGroupId}" : selectedDetailPage;

--- a/Swift/Files/Templates/Designs/Swift/eCom/ProductCatalog/ProductSlider.cshtml
+++ b/Swift/Files/Templates/Designs/Swift/eCom/ProductCatalog/ProductSlider.cshtml
@@ -183,7 +183,7 @@
 	bool neverShowVat = string.IsNullOrEmpty(showPricesWithVat);
 	
 	var defaultGroupId = product.PrimaryOrDefaultGroup.Id;
-	var productGroup = !string.IsNullOrEmpty(defaultGroupId) : Dynamicweb.Ecommerce.Services.ProductGroups.GetGroup(defaultGroupId) : null;
+	var productGroup = !string.IsNullOrEmpty(defaultGroupId) ? Dynamicweb.Ecommerce.Services.ProductGroups.GetGroup(defaultGroupId) : null;
 	var selectedDetailPage = productGroup?.Meta.PrimaryPage ?? "";
 
 	string link = string.IsNullOrEmpty(selectedDetailPage) ? $"/Default.aspx?ID={detailsPageLink}&groupid={defaultGroupId}" : selectedDetailPage;


### PR DESCRIPTION
https://github.com/dynamicweb/Swift/blob/c6b5e757ba4de31b60cd1383693c190a55a9dfef/Swift/Files/Templates/Designs/Swift/eCom/ProductCatalog/ProductSlider.cshtml#L186

After upgrading to Swift 1.5, we're getting a NullReferenceException on above line.

Error executing template "Designs/Swift/eCom/ProductCatalog/ProductSlider.cshtml"
System.NullReferenceException: Object reference not set to an instance of an object.
   at CompiledRazorTemplates.Dynamic.RazorEngine_3d1ba70203284987b627e35b051e149e.<>c__DisplayClass6_0.<RenderProduct>b__0(TextWriter __razor_helper_writer) in F:\Solutions\GASA\Files\Templates\Designs\Swift\eCom\ProductCatalog\ProductSlider.cshtml:line 186
   at CompiledRazorTemplates.Dynamic.RazorEngine_3d1ba70203284987b627e35b051e149e.<RenderSlider>b__4_0(TextWriter __razor_helper_writer) in F:\Solutions\GASA\Files\Templates\Designs\Swift\eCom\ProductCatalog\ProductSlider.cshtml:line 150
   at CompiledRazorTemplates.Dynamic.RazorEngine_3d1ba70203284987b627e35b051e149e.Execute() in F:\Solutions\GASA\Files\Templates\Designs\Swift\eCom\ProductCatalog\ProductSlider.cshtml:line 57
   at RazorEngine.Templating.TemplateBase.RazorEngine.Templating.ITemplate.Run(ExecuteContext context, TextWriter reader)
   at RazorEngine.Templating.RazorEngineService.RunCompile(ITemplateKey key, TextWriter writer, Type modelType, Object model, DynamicViewBag viewBag)
   at RazorEngine.Templating.RazorEngineServiceExtensions.<>c__DisplayClass16_0.<RunCompile>b__0(TextWriter writer)
   at RazorEngine.Templating.RazorEngineServiceExtensions.WithWriter(Action`1 withWriter)
   at Dynamicweb.Rendering.RazorTemplateRenderingProvider.Render(Template template)
   at Dynamicweb.Rendering.TemplateRenderingService.Render(Template template)
   at Dynamicweb.Rendering.Template.RenderRazorTemplate()

or could it be changed to something like:
var selectedDetailPage = Dynamicweb.Ecommerce.Services.ProductGroups.GetGroup(defaultGroupId)?.Meta.PrimaryPage ?? "";
