### PR TITLE
Search Typeahead - Correction to styling issue with highligting of dropdown results

### DIFF
--- a/Files/Templates/Designs/Swift-v2/eCom/ProductCatalog/ProductSearchDropdownResponse.cshtml
+++ b/Files/Templates/Designs/Swift-v2/eCom/ProductCatalog/ProductSearchDropdownResponse.cshtml
@@ -25,7 +25,7 @@
 			return input;
 		}
 		input = input.ToLower();
-		input = input.Replace(textToHighlight, "</mark>" + textToHighlight + "<mark>");
+		input = input.Replace(textToHighlight, "<mark>" + textToHighlight + "</mark>");
 
 		return "<span class=\"js-suggestion flex-fill text-break\" data-suggestion-value=\"\"><mark>" + input + "</mark></span>";
 	}
@@ -37,7 +37,7 @@
 			return input;
 		}
 		input = input.ToLower();
-		input = input.Replace(textToHighlight, "</mark>" + textToHighlight + "<mark>");
+		input = input.Replace(textToHighlight, "<mark>" + textToHighlight + "</mark>");
 
 		return "<span class=\"js-suggestion flex-fill text-break\" data-suggestion-value=\"\">" + input + "</span>";
 	}


### PR DESCRIPTION
There currently a styling issue with highligting of the dropdown results.
It marks everything after the searchTerm. The fix was quite simple.

**Before**
![image](https://github.com/user-attachments/assets/15dd4b4c-f973-4b55-a6d4-28d1b2952028)

**After**
![image](https://github.com/user-attachments/assets/e9e6a15f-4343-4c2c-8a59-de4fa71923e8)
